### PR TITLE
Redirect URL weird

### DIFF
--- a/hummedia/auth.py
+++ b/hummedia/auth.py
@@ -45,11 +45,7 @@ def get_profile():
     return atts
     
 def get_redirect_url():
-    r = session.get("redirect") if session.get("redirect") else url_for("profile")
-    url_parts = list(urlparse.urlparse(r))
-    query = urlparse.parse_qs(url_parts[4])
-    url_parts[4] = urllib.urlencode(query)
-    return urlparse.urlunparse(url_parts)
+    return session.get("redirect") if session.get("redirect") else url_for("profile")
   
 def set_session_vars(user):
     for att in ('username','userid','role','superuser','fullname','preferredLanguage','ta'):

--- a/hummedia/helpers.py
+++ b/hummedia/helpers.py
@@ -43,7 +43,7 @@ class OAuthProvider():
     def get_remote_app(self):
         return self.remote_app
 
-class Resource():
+class Resource(object):
     collection=connection.test.test
     model=collection.TestObject
     namespace="hummedia:id/object"
@@ -105,7 +105,7 @@ class Resource():
     def put(self,id):
         return self.post(id)
             
-    def get(self,id):
+    def get(self,id,limit=0):
         q=self.set_query()
         if id:
             try:
@@ -125,7 +125,7 @@ class Resource():
             else:
                 return bundle_404()
         else:
-            self.bundle=self.collection.find(q)
+            self.bundle=self.collection.find(q).limit(limit)
             return self.get_list()
 
     def delete(self,id):

--- a/hummedia/resources.py
+++ b/hummedia/resources.py
@@ -24,7 +24,7 @@ class UserProfile(Resource):
     namespace="hummedia:id/user"
     endpoint="account"
 
-    def get(self,id):
+    def get(self,id,limit=0):
         q=self.set_query()
         if id:
             try:
@@ -41,7 +41,7 @@ class UserProfile(Resource):
             else:
                 return bundle_404()
         else:
-            self.bundle=self.collection.find(q)
+            self.bundle=self.collection.find(q).limit(limit)
             return self.get_list()
 
     def auth_filter(self,bundle=None):
@@ -111,6 +111,7 @@ class MediaAsset(Resource):
     namespace="hummedia:id/video"
     endpoint="video"
     override_only_triggers=['enrollment']
+    max_search_results = 20
     
     def set_disallowed_atts(self):
         self.disallowed_atts=["dc:identifier","pid","dc:type","url"]
@@ -118,6 +119,12 @@ class MediaAsset(Resource):
         atts=get_profile()
         if not atts['superuser']:
             self.disallowed_atts.append("dc:creator")
+
+    def get(self,id,limit=0):
+        if self.request.args.get("q", None) is not None:
+            if limit is 0:
+                return super(MediaAsset, self).get(id, self.max_search_results)
+        return super(MediaAsset, self).get(id, limit)
     
     def set_query(self):
         q={}

--- a/hummedia/test/conftest.py
+++ b/hummedia/test/conftest.py
@@ -12,7 +12,7 @@ def ACCOUNTS():
   Account data that can be passed into app.login().
   Contains session information.
   '''
-  return {'SUPERUSER': {'superuser': True}}
+  return {'SUPERUSER': {'superuser': True, 'username': 'arbitraryname'}}
 
 @pytest.fixture
 def ASSETS():
@@ -27,12 +27,6 @@ def app():
   '''
   returns a test client for hummedia
   '''
-  hummedia.app.config.update(
-      SESSION_COOKIE_DOMAIN = None,
-      TESTING = True
-  )
-  config.SUBTITLE_DIRECTORY = tempfile.mkdtemp('hummedia') + os.sep
-
   client = hummedia.app.test_client()
 
   def login(self, account):
@@ -47,3 +41,12 @@ def raise_(ex):
   Helpful when monkeypatching methods that should return specific exeptions
   '''
   raise ex
+
+@pytest.fixture(autouse=True)
+def configure():
+  hummedia.app.config.update(
+      SESSION_COOKIE_DOMAIN = None,
+      MONGODB_DB = 'AUTOMATED_TESTS',
+      TESTING = True
+  )
+  config.SUBTITLE_DIRECTORY = tempfile.mkdtemp('hummedia') + os.sep

--- a/hummedia/test/test_auth.py
+++ b/hummedia/test/test_auth.py
@@ -1,0 +1,10 @@
+def test_redirect_url(app, ACCOUNTS):
+  url = 'http://localhost?q=dog'
+  
+  app.login(ACCOUNTS['SUPERUSER'])
+
+  with app.session_transaction() as sess:
+    sess['redirect'] = url
+
+  result = app.get('/account/login?r=' + url)
+  assert url == result.headers['location']

--- a/hummedia/test/test_video.py
+++ b/hummedia/test/test_video.py
@@ -1,5 +1,5 @@
 import pytest
-
+import json
 
 def test_youtube_with_bad_key(monkeypatch):
   import urllib2 
@@ -12,3 +12,31 @@ def test_youtube_with_bad_key(monkeypatch):
   assert thumbs[vid].has_key('thumb') 
   assert thumbs[vid]['thumb'] is None
   assert thumbs[vid]['poster'] is None
+
+def test_limit_search(app, ACCOUNTS, monkeypatch):
+  from ..resources import MediaAsset
+
+  monkeypatch.setattr(MediaAsset, 'max_search_results', 2)
+
+  # TODO: use a mock database so we don't have to wipe it
+  MediaAsset.collection.database.drop_collection('assets')
+  MediaAsset.collection.database.create_collection('assets')
+
+  title = "Wolfeschlegelstein"
+
+  app.login(ACCOUNTS['SUPERUSER'])
+  total_films = MediaAsset.max_search_results + 2;
+  mock_data = {"ma:title":title,"dc:coverage":"private","ma:hasLanguage":["en"],"ma:description":"","ma:date":"2014","url":["http://youtu.be/h2tfjG4tzWY"],"type":"yt"}
+
+  for i in range(0, total_films):
+    response = app.post('/video', data=json.dumps(mock_data),
+        content_type='application/json')
+    assert response.status_code == 200
+  
+  response = app.get('/video')
+  data = json.loads(response.data)
+  assert len(data) == total_films
+  
+  response = app.get('/video?q=' + title)
+  data = json.loads(response.data)
+  assert len(data) == MediaAsset.max_search_results


### PR DESCRIPTION
The redirect URL gets transformed from something like `?q=hello` to `?q=[u'hello']`, and the API has trouble dealing with the query. Is there a reason this is being transformed into a list?
