### PR TITLE
Empty date field bug fix

### DIFF
--- a/hummedia/resources.py
+++ b/hummedia/resources.py
@@ -301,9 +301,15 @@ class MediaAsset(Resource):
                 elif self.model.structure['@graph'][k]==type(u""):
                     self.bundle["@graph"][k]=unicode(v)
                 elif self.model.structure['@graph'][k]==type(2):
-                    self.bundle["@graph"][k]=int(v) if v is not None else 0
+                    try:
+                        self.bundle["@graph"][k]=int(v)
+                    except ValueError:
+                        self.bundle["@graph"][k]=0
                 elif self.model.structure['@graph'][k]==type(2.0):
-                    self.bundle["@graph"][k]=float(v) if v is not None else 0
+                    try:
+                        self.bundle["@graph"][k]=float(v)
+                    except ValueError:
+                        self.bundle["@graph"][k]=0
                 elif type(self.model.structure['@graph'][k])==type([]):
                     self.bundle["@graph"][k]=[]
                     for i in v:

--- a/hummedia/test/test_video.py
+++ b/hummedia/test/test_video.py
@@ -57,8 +57,7 @@ def test_patch_video_without_good_date(app, ACCOUNTS):
   pid = response['pid']
   patch = {
     'ma:title': 'Ghostbusters',
-    'ma:date': '',
-    'pid': pid
+    'ma:date': ''
   } 
 
   result = app.patch('/video/' + pid, data=json.dumps(patch), content_type='application/json')


### PR DESCRIPTION
I assume this stays within the "spirit of the code." There was a bug where if someone patched a date field with an empty string, the web service threw a 500 error.

The only issue I can see with this is is it would mask errors if someone submitted a date like "30 BC" or "yesterday."

I'll go ahead and merge this in, unless you have any concerns.
